### PR TITLE
Enable ANT

### DIFF
--- a/app/src/main/java/com/valterc/ki2/ant/AntManager.java
+++ b/app/src/main/java/com/valterc/ki2/ant/AntManager.java
@@ -130,7 +130,7 @@ public class AntManager {
                     return;
                 }
 
-                Timber.w("Ant disabled");
+                Timber.w("ANT disabled");
                 if (stateListener != null) {
                     stateListener.onAntDisabled();
                 }
@@ -151,7 +151,7 @@ public class AntManager {
 
     private void triggerStateChange() {
         if (stateListener != null) {
-            stateListener.onAntStateChange(isReady());
+            stateListener.onAntServiceStateChange(isAntServiceReady());
         }
     }
 
@@ -193,7 +193,7 @@ public class AntManager {
             ChannelConfiguration channelConfiguration,
             IAntChannelEventHandler channelEventHandler,
             IAntAdapterEventHandler adapterEventHandler) throws Exception {
-        if (!isReady()) {
+        if (!isAntServiceReady()) {
             throw new RuntimeException("ANT channel provider is not available");
         }
 
@@ -257,7 +257,7 @@ public class AntManager {
             ScanChannelConfiguration scanChannelConfiguration,
             IAntChannelEventHandler channelEventHandler,
             IAntAdapterEventHandler adapterEventHandler) throws Exception {
-        if (!isReady()) {
+        if (!isAntServiceReady()) {
             throw new RuntimeException("ANT channel provider is not available");
         }
 
@@ -309,11 +309,11 @@ public class AntManager {
     }
 
     /**
-     * Indicates if the ANT manager is ready to create ANT channels.
+     * Indicates if the ANT service is ready.
      *
-     * @return True if ANT is ready, False otherwise.
+     * @return True if ANT service is ready, False otherwise.
      */
-    public boolean isReady() {
+    public boolean isAntServiceReady() {
         return antChannelProvider != null;
     }
 

--- a/app/src/main/java/com/valterc/ki2/ant/AntManager.java
+++ b/app/src/main/java/com/valterc/ki2/ant/AntManager.java
@@ -48,7 +48,6 @@ public class AntManager {
 
     private boolean disposed;
     private boolean antServiceBound;
-    private boolean antEnabled;
     private AntService antService;
     private AntChannelProvider antChannelProvider;
 
@@ -108,8 +107,7 @@ public class AntManager {
     }
 
     private void ensureAntEnabled() {
-        antEnabled = AntSettings.isAntEnabled(context);
-        if (!antEnabled) {
+        if (!AntSettings.isAntEnabled(context)) {
             if (stateListener != null) {
                 stateListener.onAntDisabled();
             }
@@ -123,9 +121,7 @@ public class AntManager {
 
             @Override
             public void onChange(boolean selfChange) {
-                antEnabled = AntSettings.isAntEnabled(context);
-
-                if (antEnabled) {
+                if (AntSettings.isAntEnabled(context)) {
                     return;
                 }
 

--- a/app/src/main/java/com/valterc/ki2/ant/AntSettings.java
+++ b/app/src/main/java/com/valterc/ki2/ant/AntSettings.java
@@ -1,0 +1,26 @@
+package com.valterc.ki2.ant;
+
+import android.content.Context;
+import android.net.Uri;
+import android.provider.Settings;
+
+public final class AntSettings {
+
+    private AntSettings() {
+    }
+
+    public static final String ENABLED = "ant_plus_enabled";
+
+    public static Uri getEnabledUri() {
+        return Settings.Global.getUriFor(ENABLED);
+    }
+
+    public static boolean isAntEnabled(Context context) {
+        return Settings.Global.getInt(context.getContentResolver(), ENABLED, 0) == 1;
+    }
+
+    public static void enableAnt(Context context) {
+        Settings.Global.putInt(context.getContentResolver(), ENABLED, 1);
+    }
+
+}

--- a/app/src/main/java/com/valterc/ki2/ant/IAntStateListener.java
+++ b/app/src/main/java/com/valterc/ki2/ant/IAntStateListener.java
@@ -3,6 +3,11 @@ package com.valterc.ki2.ant;
 public interface IAntStateListener {
 
     /**
+     * Invoked when ANT radio is disabled system wide.
+     */
+    void onAntDisabled();
+
+    /**
      * Invoked when the state of AntManager changes.
      * @param ready Indicates if ANT is ready.
      */

--- a/app/src/main/java/com/valterc/ki2/ant/IAntStateListener.java
+++ b/app/src/main/java/com/valterc/ki2/ant/IAntStateListener.java
@@ -8,9 +8,9 @@ public interface IAntStateListener {
     void onAntDisabled();
 
     /**
-     * Invoked when the state of AntManager changes.
-     * @param ready Indicates if ANT is ready.
+     * Invoked when the state of ANT service changes.
+     * @param serviceReady Indicates if ANT service is ready.
      */
-    void onAntStateChange(boolean ready);
+    void onAntServiceStateChange(boolean serviceReady);
 
 }

--- a/app/src/main/java/com/valterc/ki2/ant/connection/AntConnectionManager.java
+++ b/app/src/main/java/com/valterc/ki2/ant/connection/AntConnectionManager.java
@@ -49,13 +49,6 @@ public class AntConnectionManager {
     }
 
     public void connect(Collection<DeviceId> devices, IDeviceConnectionListener deviceConnectionListener) throws Exception {
-        int newDeviceCount = (int) devices.stream().filter(d -> !connectionMap.containsKey(d)).count();
-        int availableAntChannels = antManager.getAvailableChannelCount();
-
-        if (newDeviceCount > availableAntChannels) {
-            throw new Exception("Not enough ANT channels available. Requested: " + newDeviceCount + ", available: " + availableAntChannels);
-        }
-
         for (DeviceId deviceId : devices) {
             connect(deviceId, deviceConnectionListener, false);
         }

--- a/app/src/main/java/com/valterc/ki2/ant/scanner/AntScanner.java
+++ b/app/src/main/java/com/valterc/ki2/ant/scanner/AntScanner.java
@@ -70,7 +70,7 @@ public class AntScanner {
                 stopScan();
 
                 try {
-                    if (antManager.isReady()) {
+                    if (antManager.isAntServiceReady()) {
                         startScan(scanChannelConfiguration);
                     }
                 } catch (Exception e) {

--- a/app/src/main/java/com/valterc/ki2/data/message/EnableAntMessage.java
+++ b/app/src/main/java/com/valterc/ki2/data/message/EnableAntMessage.java
@@ -1,0 +1,25 @@
+package com.valterc.ki2.data.message;
+
+import android.os.Bundle;
+
+public class EnableAntMessage extends Message {
+
+    public static final String KEY = "enable-ant";
+
+    public static EnableAntMessage parse(Message message) {
+        if (!message.getClassType().equals(EnableAntMessage.class.getName())) {
+            return null;
+        }
+
+        return new EnableAntMessage(message);
+    }
+
+
+    private EnableAntMessage(Message message) {
+        super(message);
+    }
+
+    public EnableAntMessage() {
+        super(KEY, new Bundle(), MessageType.ENABLE_ANT, true);
+    }
+}

--- a/app/src/main/java/com/valterc/ki2/data/message/MessageType.java
+++ b/app/src/main/java/com/valterc/ki2/data/message/MessageType.java
@@ -11,7 +11,8 @@ public enum MessageType {
     AUDIO_ALERT_EVENT(6),
     AUDIO_ALERT_TOGGLE(7),
     AUDIO_ALERT_DISABLE(8),
-    AUDIO_ALERT_ENABLE(9);
+    AUDIO_ALERT_ENABLE(9),
+    ENABLE_ANT(10);
 
     public static MessageType fromValue(int value) {
         for (MessageType messageType : values()) {

--- a/app/src/main/java/com/valterc/ki2/fragments/devices/add/AddDeviceFragment.java
+++ b/app/src/main/java/com/valterc/ki2/fragments/devices/add/AddDeviceFragment.java
@@ -29,7 +29,7 @@ import timber.log.Timber;
 
 public class AddDeviceFragment extends Fragment implements IKarooKeyListener {
 
-    private static final long DURATION_SCAN_MS = 20_000;
+    private static final long DURATION_SCAN_MS = 30_000;
 
     private final Handler handlerStopScan = new Handler();
     private boolean serviceBound;

--- a/app/src/main/java/com/valterc/ki2/karoo/Ki2Module.java
+++ b/app/src/main/java/com/valterc/ki2/karoo/Ki2Module.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import com.valterc.ki2.BuildConfig;
 import com.valterc.ki2.data.message.RideStatusMessage;
 import com.valterc.ki2.data.ride.RideStatus;
+import com.valterc.ki2.karoo.ant.AntEnablerHandler;
 import com.valterc.ki2.karoo.battery.LowBatteryHandler;
 import com.valterc.ki2.karoo.datatypes.BatteryGraphicalDataType;
 import com.valterc.ki2.karoo.datatypes.BatteryPercentageTextDataType;
@@ -73,7 +74,8 @@ public class Ki2Module extends Module {
                     new UpdateAvailableHandler(ki2Context),
                     new LowBatteryHandler(ki2Context),
                     new ShiftingAudioAlertHandler(ki2Context),
-                    new ShiftingReportingManager(ki2Context)));
+                    new ShiftingReportingManager(ki2Context),
+                    new AntEnablerHandler(ki2Context)));
         } else if (RideActivityHook.isRideActivityProcess()) {
             handlerManager = new HandlerManager(ki2Context, Collections.singletonList(new OverlayManager(ki2Context)));
         } else {

--- a/app/src/main/java/com/valterc/ki2/karoo/ant/AntEnablerHandler.java
+++ b/app/src/main/java/com/valterc/ki2/karoo/ant/AntEnablerHandler.java
@@ -1,0 +1,31 @@
+package com.valterc.ki2.karoo.ant;
+
+import android.annotation.SuppressLint;
+
+import com.valterc.ki2.data.message.EnableAntMessage;
+import com.valterc.ki2.karoo.Ki2Context;
+import com.valterc.ki2.karoo.handlers.IRideHandler;
+import com.valterc.ki2.karoo.hooks.ActivityServiceAntHook;
+
+import java.util.function.Consumer;
+
+@SuppressWarnings("FieldCanBeLocal")
+@SuppressLint("LogNotTimber")
+public class AntEnablerHandler implements IRideHandler {
+
+    private final Ki2Context context;
+
+    private final Consumer<EnableAntMessage> onEnableAntMessage = this::onEnableAntMessage;
+
+    public AntEnablerHandler(Ki2Context context) {
+        this.context = context;
+        context.getServiceClient().getCustomMessageClient().registerEnableAntWeakListener(onEnableAntMessage);
+
+        ActivityServiceAntHook.ensureAntEnabled(context.getSdkContext().getBaseContext());
+    }
+
+    private void onEnableAntMessage(EnableAntMessage updateAvailableMessage) {
+        ActivityServiceAntHook.ensureAntEnabled(context.getSdkContext().getBaseContext());
+    }
+
+}

--- a/app/src/main/java/com/valterc/ki2/karoo/hooks/ActivityServiceAntHook.java
+++ b/app/src/main/java/com/valterc/ki2/karoo/hooks/ActivityServiceAntHook.java
@@ -1,0 +1,32 @@
+package com.valterc.ki2.karoo.hooks;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.util.Log;
+
+import com.valterc.ki2.ant.AntSettings;
+
+@SuppressWarnings("UnusedReturnValue")
+@SuppressLint("LogNotTimber")
+public class ActivityServiceAntHook {
+
+    private ActivityServiceAntHook() {
+    }
+
+    public static boolean ensureAntEnabled(Context context) {
+        try {
+            if (AntSettings.isAntEnabled(context)) {
+                return true;
+            }
+
+            AntSettings.enableAnt(context);
+            Log.i("KI2", "Enabled ANT");
+            return true;
+        } catch (Exception e) {
+            Log.w("KI2", "Error enabling Ant", e);
+        }
+
+        return false;
+    }
+
+}

--- a/app/src/main/java/com/valterc/ki2/karoo/service/messages/CustomMessageClient.java
+++ b/app/src/main/java/com/valterc/ki2/karoo/service/messages/CustomMessageClient.java
@@ -4,6 +4,7 @@ import android.os.Handler;
 
 import com.valterc.ki2.data.message.AudioAlertEventMessage;
 import com.valterc.ki2.data.message.AudioAlertMessage;
+import com.valterc.ki2.data.message.EnableAntMessage;
 import com.valterc.ki2.data.message.Message;
 import com.valterc.ki2.data.message.MessageType;
 import com.valterc.ki2.data.message.RideStatusMessage;
@@ -32,6 +33,7 @@ public class CustomMessageClient {
         customMessageHandlers.put(MessageType.SHOW_OVERLAY, new CustomMessageHandler<>(MessageType.SHOW_OVERLAY, ShowOverlayMessage::parse));
         customMessageHandlers.put(MessageType.AUDIO_ALERT, new CustomMessageHandler<>(MessageType.AUDIO_ALERT, AudioAlertMessage::parse));
         customMessageHandlers.put(MessageType.AUDIO_ALERT_EVENT, new CustomMessageHandler<>(MessageType.AUDIO_ALERT_EVENT, AudioAlertEventMessage::parse));
+        customMessageHandlers.put(MessageType.ENABLE_ANT, new CustomMessageHandler<>(MessageType.ENABLE_ANT, EnableAntMessage::parse));
 
         serviceClient.registerMessageWeakListener(onMessage);
     }
@@ -112,6 +114,21 @@ public class CustomMessageClient {
         handler.post(() -> {
             CustomMessageHandler<AudioAlertEventMessage> customMessageHandler =
                     (CustomMessageHandler<AudioAlertEventMessage>) customMessageHandlers.get(MessageType.AUDIO_ALERT_EVENT);
+            if (customMessageHandler != null) {
+                customMessageHandler.addListener(consumer);
+            }
+        });
+    }
+
+    /**
+     * Register a weak referenced listener that will receive Enable Ant messages.
+     *
+     * @param consumer Consumer that will receive Enable Ant messages. It will be referenced using a weak reference so the owner must keep a strong reference.
+     */
+    public void registerEnableAntWeakListener(Consumer<EnableAntMessage> consumer) {
+        handler.post(() -> {
+            CustomMessageHandler<EnableAntMessage> customMessageHandler =
+                    (CustomMessageHandler<EnableAntMessage>) customMessageHandlers.get(MessageType.ENABLE_ANT);
             if (customMessageHandler != null) {
                 customMessageHandler.addListener(consumer);
             }

--- a/app/src/main/java/com/valterc/ki2/services/Ki2Service.java
+++ b/app/src/main/java/com/valterc/ki2/services/Ki2Service.java
@@ -581,9 +581,7 @@ public class Ki2Service extends Service implements IAntStateListener, IAntScanLi
 
     private void processScan() throws Exception {
         if (callbackListScan.getRegisteredCallbackCount() != 0) {
-            ensureAntEnabled();
-
-            if (antManager.isReady()) {
+            if (antManager.isAntServiceReady()) {
                 antScanner.startScan(ConfigurationStore.getScanChannelConfiguration(Ki2Service.this));
             }
         } else {
@@ -602,9 +600,7 @@ public class Ki2Service extends Service implements IAntStateListener, IAntScanLi
                 || callbackListManufacturerInfo.getRegisteredCallbackCount() != 0
                 || callbackListShifting.getRegisteredCallbackCount() != 0
                 || callbackListKey.getRegisteredCallbackCount() != 0) {
-            ensureAntEnabled();
-
-            if (antManager.isReady()) {
+            if (antManager.isAntServiceReady()) {
                 Collection<DeviceId> enabledDevices = devices.stream()
                         .filter(deviceId -> new DevicePreferences(this, deviceId).isEnabled())
                         .collect(Collectors.toList());
@@ -645,12 +641,12 @@ public class Ki2Service extends Service implements IAntStateListener, IAntScanLi
     }
 
     @Override
-    public void onAntStateChange(boolean ready) {
+    public void onAntServiceStateChange(boolean serviceReady) {
         serviceHandler.postAction(() -> {
             antScanner.stopScan();
             antConnectionManager.disconnectAll();
 
-            if (ready) {
+            if (serviceReady) {
                 serviceHandler.postRetriableAction(Ki2Service.this::processScan);
                 serviceHandler.postRetriableAction(Ki2Service.this::processConnections);
             }

--- a/app/src/main/java/com/valterc/ki2/services/Ki2Service.java
+++ b/app/src/main/java/com/valterc/ki2/services/Ki2Service.java
@@ -17,6 +17,7 @@ import androidx.preference.PreferenceManager;
 
 import com.valterc.ki2.R;
 import com.valterc.ki2.ant.AntManager;
+import com.valterc.ki2.ant.AntSettings;
 import com.valterc.ki2.ant.IAntStateListener;
 import com.valterc.ki2.ant.connection.AntConnectionManager;
 import com.valterc.ki2.ant.connection.IAntDeviceConnection;
@@ -34,6 +35,7 @@ import com.valterc.ki2.data.device.DeviceStore;
 import com.valterc.ki2.data.info.DataType;
 import com.valterc.ki2.data.info.ManufacturerInfo;
 import com.valterc.ki2.data.input.KarooKeyEvent;
+import com.valterc.ki2.data.message.EnableAntMessage;
 import com.valterc.ki2.data.message.Message;
 import com.valterc.ki2.data.message.MessageManager;
 import com.valterc.ki2.data.message.RideStatusMessage;
@@ -496,7 +498,10 @@ public class Ki2Service extends Service implements IAntStateListener, IAntScanLi
         @Override
         public void onReceive(final Context context, final Intent intent) {
             Timber.d("Received reconnect devices broadcast");
-            serviceHandler.postRetriableAction(() -> antConnectionManager.restartClosedConnections(Ki2Service.this));
+            serviceHandler.postRetriableAction(() -> {
+                ensureAntEnabled();
+                antConnectionManager.restartClosedConnections(Ki2Service.this);
+            });
         }
     };
 
@@ -545,8 +550,8 @@ public class Ki2Service extends Service implements IAntStateListener, IAntScanLi
         PostUpdateActions.executePostInit(new PostUpdateContext(this, deviceStore));
         devicePreferencesStore.setDevices(deviceStore.getDevices());
 
-        registerReceiver(receiverReconnectDevices, new IntentFilter("io.hammerhead.action.RECONNECT_DEVICES"));
-        registerReceiver(receiverInRide, new IntentFilter("io.hammerhead.action.IN_RIDE"));
+        registerReceiver(receiverReconnectDevices, new IntentFilter("io.hammerhead.action.RECONNECT_DEVICES"), Context.RECEIVER_EXPORTED);
+        registerReceiver(receiverInRide, new IntentFilter("io.hammerhead.action.IN_RIDE"), Context.RECEIVER_EXPORTED);
         Timber.i("Service created");
     }
 
@@ -576,6 +581,8 @@ public class Ki2Service extends Service implements IAntStateListener, IAntScanLi
 
     private void processScan() throws Exception {
         if (callbackListScan.getRegisteredCallbackCount() != 0) {
+            ensureAntEnabled();
+
             if (antManager.isReady()) {
                 antScanner.startScan(ConfigurationStore.getScanChannelConfiguration(Ki2Service.this));
             }
@@ -595,6 +602,8 @@ public class Ki2Service extends Service implements IAntStateListener, IAntScanLi
                 || callbackListManufacturerInfo.getRegisteredCallbackCount() != 0
                 || callbackListShifting.getRegisteredCallbackCount() != 0
                 || callbackListKey.getRegisteredCallbackCount() != 0) {
+            ensureAntEnabled();
+
             if (antManager.isReady()) {
                 Collection<DeviceId> enabledDevices = devices.stream()
                         .filter(deviceId -> new DevicePreferences(this, deviceId).isEnabled())
@@ -646,6 +655,11 @@ public class Ki2Service extends Service implements IAntStateListener, IAntScanLi
                 serviceHandler.postRetriableAction(Ki2Service.this::processConnections);
             }
         });
+    }
+
+    @Override
+    public void onAntDisabled() {
+        ensureAntEnabled();
     }
 
     @Override
@@ -792,7 +806,7 @@ public class Ki2Service extends Service implements IAntStateListener, IAntScanLi
         SharedPreferences preferences;
         SharedPreferences.Editor editor;
 
-        switch (message.getMessageType()){
+        switch (message.getMessageType()) {
             case RIDE_STATUS:
                 RideStatusMessage rideStatusMessage = RideStatusMessage.parse(message);
                 if (rideStatusMessage != null) {
@@ -848,6 +862,14 @@ public class Ki2Service extends Service implements IAntStateListener, IAntScanLi
         serviceHandler.postRetriableAction(() -> broadcastData(callbackListDevicePreferences,
                 () -> devicePreferencesView, (callback, devicePreferences) -> callback.onDevicePreferences(deviceId, devicePreferences)));
         serviceHandler.postRetriableAction(Ki2Service.this::processConnections);
+    }
+
+    private void ensureAntEnabled() {
+        if (AntSettings.isAntEnabled(this)) {
+            return;
+        }
+
+        serviceHandler.postAction(() -> onMessage(new EnableAntMessage()));
     }
 
 }


### PR DESCRIPTION
If no ANT device is paired in Karoo sensors, then Karoo OS will disable the ANT radio system wide, which prevents any other apps from using ANT. 

This PR detects if ANT is disabled and enables it automatically.