### PR TITLE
Allow to open bottom drawer using di2 buttons

### DIFF
--- a/app/src/main/java/com/valterc/ki2/data/action/KarooAction.java
+++ b/app/src/main/java/com/valterc/ki2/data/action/KarooAction.java
@@ -27,7 +27,8 @@ public enum KarooAction {
     VIRTUAL_LAP,
     VIRTUAL_ZOOM_OUT,
     VIRTUAL_ZOOM_IN,
-    VIRTUAL_CONTROL_CENTER;
+    VIRTUAL_CONTROL_CENTER,
+    VIRTUAL_DRAWER_ACTION;
 
     private static final KarooAction[] values = KarooAction.values();
 

--- a/app/src/main/java/com/valterc/ki2/input/ActionAdapter.java
+++ b/app/src/main/java/com/valterc/ki2/input/ActionAdapter.java
@@ -54,6 +54,7 @@ public class ActionAdapter {
         this.keyMapping.put(KarooAction.VIRTUAL_ZOOM_IN, karooKeyEvent -> context.getKarooSystem().dispatch(new ZoomPage(true)));
         this.keyMapping.put(KarooAction.VIRTUAL_ZOOM_OUT, karooKeyEvent -> context.getKarooSystem().dispatch(new ZoomPage(false)));
         this.keyMapping.put(KarooAction.VIRTUAL_CONTROL_CENTER, karooKeyEvent -> context.getKarooSystem().dispatch(PerformHardwareAction.ControlCenterComboPress.INSTANCE));
+        this.keyMapping.put(KarooAction.VIRTUAL_DRAWER_ACTION, karooKeyEvent -> context.getKarooSystem().dispatch(PerformHardwareAction.DrawerActionComboPress.INSTANCE));
     }
 
     private void showToast(Ki2ExtensionContext context, int textResId) {

--- a/app/src/main/java/com/valterc/ki2/input/InputManager.java
+++ b/app/src/main/java/com/valterc/ki2/input/InputManager.java
@@ -56,6 +56,7 @@ public class InputManager {
         preferenceToSwitchKeyMap.put("press_double_beep", (switchEvent, converter) -> new KarooActionEvent(KarooAction.VIRTUAL_DOUBLE_BEEP, switchEvent.getRepeat()));
         preferenceToSwitchKeyMap.put("press_bell", (switchEvent, converter) -> new KarooActionEvent(KarooAction.VIRTUAL_BELL, switchEvent.getRepeat()));
         preferenceToSwitchKeyMap.put("press_control_center", (switchEvent, converter) -> new KarooActionEvent(KarooAction.VIRTUAL_CONTROL_CENTER, switchEvent.getRepeat()));
+        preferenceToSwitchKeyMap.put("press_drawer_action", (switchEvent, converter) -> new KarooActionEvent(KarooAction.VIRTUAL_DRAWER_ACTION, switchEvent.getRepeat()));
         preferenceToSwitchKeyMap.put("press_toggle_overlay", (switchEvent, converter) -> new KarooActionEvent(KarooAction.VIRTUAL_TOGGLE_OVERLAY, switchEvent.getRepeat()));
         preferenceToSwitchKeyMap.put("press_hide_overlay", (switchEvent, converter) -> new KarooActionEvent(KarooAction.VIRTUAL_HIDE_OVERLAY, switchEvent.getRepeat()));
         preferenceToSwitchKeyMap.put("press_show_overlay", (switchEvent, converter) -> new KarooActionEvent(KarooAction.VIRTUAL_SHOW_OVERLAY, switchEvent.getRepeat()));
@@ -103,6 +104,13 @@ public class InputManager {
             }
 
             return new KarooActionEvent(KarooAction.VIRTUAL_CONTROL_CENTER, 0);
+        });
+        preferenceToSwitchKeyMap.put("hold_short_single_drawer_action", (switchEvent, converter) -> {
+            if (switchEvent.getCommand() != SwitchCommand.LONG_PRESS_DOWN) {
+                return null;
+            }
+
+            return new KarooActionEvent(KarooAction.VIRTUAL_DRAWER_ACTION, 0);
         });
         preferenceToSwitchKeyMap.put("map_graph_slow_zoom_out", (switchEvent, converter) -> {
             if (switchEvent.getCommand() == SwitchCommand.LONG_PRESS_UP ||

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -21,6 +21,7 @@
         <item>Double Beep</item>
         <item>Bell</item>
         <item>Control Center</item>
+        <item>Drawer</item>
     </string-array>
 
     <string-array name="preference_values_switch_single_press_action">
@@ -45,6 +46,7 @@
         <item>press_double_beep</item>
         <item>press_bell</item>
         <item>press_control_center</item>
+        <item>press_drawer_action</item>
     </string-array>
 
     <string-array name="preference_titles_switch_double_press_action">
@@ -70,6 +72,7 @@
         <item>Double Beep</item>
         <item>Bell</item>
         <item>Control Center</item>
+        <item>Drawer</item>
     </string-array>
 
     <string-array name="preference_values_switch_double_press_action">
@@ -95,6 +98,7 @@
         <item>press_double_beep</item>
         <item>press_bell</item>
         <item>press_control_center</item>
+        <item>press_drawer_action</item>
     </string-array>
 
     <string-array name="preference_titles_switch_hold_action">
@@ -122,6 +126,7 @@
         <item>Double Beep</item>
         <item>Bell</item>
         <item>Control Center</item>
+        <item>Drawer</item>
         <item>Continuous Single Beep</item>
         <item>Continuous Bell</item>
     </string-array>
@@ -151,6 +156,7 @@
         <item>hold_short_single_double_beep</item>
         <item>hold_short_single_bell</item>
         <item>hold_short_single_control_center</item>
+        <item>hold_short_single_drawer_action</item>
         <item>hold_continuous_single_beep</item>
         <item>hold_continuous_bell</item>
     </string-array>


### PR DESCRIPTION
The PR adds the option to configure the hood buttons of the Di2 to open the bottom drawer of the Karoo with the instructions, POIs and climbs. Addresses issue #290 

I've tested these changes on my Karoo 3 and everything works as expected.