### PR TITLE
Fix typo in front/rear gear data type ids

### DIFF
--- a/app/src/main/res/xml/karoo_extension_info.xml
+++ b/app/src/main/res/xml/karoo_extension_info.xml
@@ -44,28 +44,28 @@
         displayName="Front Gear"
         graphical="true"
         icon="@drawable/ic_hh_gear"
-        typeId="DATATYPE_FRONT_GEARS_INDEX" />
+        typeId="DATATYPE_FRONT_GEAR_INDEX" />
 
     <DataType
         description="View with front gear size (teeth count)."
         displayName="Front Gear T"
         graphical="true"
         icon="@drawable/ic_hh_gear"
-        typeId="DATATYPE_FRONT_GEARS_SIZE" />
+        typeId="DATATYPE_FRONT_GEAR_SIZE" />
 
     <DataType
         description="View with rear gear index."
         displayName="Rear Gear"
         graphical="true"
         icon="@drawable/ic_hh_gear"
-        typeId="DATATYPE_REAR_GEARS_INDEX" />
+        typeId="DATATYPE_REAR_GEAR_INDEX" />
 
     <DataType
         description="View with rear gear size (teeth count)."
         displayName="Rear Gear T"
         graphical="true"
         icon="@drawable/ic_hh_gear"
-        typeId="DATATYPE_REAR_GEARS_SIZE" />
+        typeId="DATATYPE_REAR_GEAR_SIZE" />
 
     <DataType
         description="View with total shift count."


### PR DESCRIPTION
While adding the Rear Gear T data field to a Karoo profile, it rendered empty. It shows the title of the data field but no content, just blank. 

Digging in, DataTypeImpl was registered with singular "GEAR" ids while the Karoo extension manifest declares them as "GEARS", so Karoo never matched these standalone data fields to their implementations. Front gear index/size had the same mismatch and are fixed too.

Built the APK and sideloaded it to my Karoo 2 to validate the fix and it does indeed make Rear Gear T and Rear Gear display properly, getting rid of the empty datafield and replacing it with the proper tooth count or gear number I'm in depending on what I'm trying to display.

I tested this with my Deore M6250 Di2 12 speed rear derailleur. 